### PR TITLE
(Draft) Fix rendering problems

### DIFF
--- a/src/components/OptionForm.vue
+++ b/src/components/OptionForm.vue
@@ -2,8 +2,8 @@
   <!-- DROPDOWN -->
   <div v-if="option.type === 'dropdown'">
     {{option.title}}
-    <select :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="dropdownChange">
-      <option :value="choice.value" v-for="choice in option.data">{{choice.name}}</option>
+    <select :data-module="name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="dropdownChange">
+      <option :value="choice.value" v-for="choice in option.data" :key="choice.value">{{choice.name}}</option>
     </select>
   </div>
   <!-- RADIO -->
@@ -12,17 +12,17 @@
   </div>
   <!-- CHECK -->
   <div v-else-if="option.type === 'check'">
-    {{option.title}} <input type="checkbox" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" v-on:change="checkChange" :checked="value ? 'checked' : ''">
+    {{option.title}} <input type="checkbox" :data-module="name" :data-optid="option.id" :data-notice="option.notice" v-on:change="checkChange" :checked="value ? 'checked' : ''">
   </div>
   <!-- TEXT -->
   <div v-else>
-    {{option.title}} <input type="text" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="textChange">
+    {{option.title}} <input type="text" :data-module="name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="textChange">
   </div>
 </template>
 
 <script>
 export default {
-  props: [ 'meta', 'option', 'config', 'notice' ],
+  props: [ 'name', 'option', 'config', 'notice' ],
   data() {
     return {
       value: this.config.get(this.option.id)
@@ -39,12 +39,12 @@ export default {
       this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.checked, evt.target.getAttribute('data-notice'))
     },
     updateConfig: function(optId, value, notice){
-      if (notice) this.notice = notice
+      if (notice) this.$emit('notice', notice)
       this.config.set(optId, value)
     }
   },
   mounted() {
-    // this.config = new HioriSDK.Options(this.meta.name)
+    // this.config = new HioriSDK.Options(this.name)
     this.$forceUpdate()
   }
 }

--- a/src/components/OptionsModule.vue
+++ b/src/components/OptionsModule.vue
@@ -3,8 +3,8 @@
     <div class="module-name"><code>{{meta.name}}</code></div>
     <div class="module-desc">{{meta.description}}</div>
     <div class="module-options">
-      <div class="module-option" v-for="option in meta.options">
-        <OptionsSelector :meta="meta" :option="option" :config="config" :notice="notice" />
+      <div class="module-option" v-for="option in meta.options" :key="option.id">
+        <OptionForm :name="meta.name" :option="option" :config="config" v-on:notice="callNotice" />
       </div>
     </div>
     <div class="module-notice" v-show="notice">{{notice}}</div>
@@ -13,7 +13,7 @@
 
 <script>
 import HioriSDK from '@sdk'
-import OptionsSelector from './OptionsSelect.vue'
+import OptionForm from './OptionForm.vue'
 export default {
   props: [ 'meta' ],
   data() {
@@ -22,8 +22,13 @@ export default {
       notice: ''
     }
   },
+  methods: {
+    callNotice(notice) {
+      if (notice) this.notice = notice
+    }
+  },
   components: {
-    OptionsSelector
+    OptionForm
   }
 }
 </script>

--- a/src/components/OptionsModule.vue
+++ b/src/components/OptionsModule.vue
@@ -4,25 +4,7 @@
     <div class="module-desc">{{meta.description}}</div>
     <div class="module-options">
       <div class="module-option" v-for="option in meta.options">
-        <!-- DROPDOWN -->
-        <div v-if="option.type === 'dropdown'">
-          {{option.title}}
-          <select :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="config.get(option.id)" v-on:change="dropdownChange">
-            <option :value="choice.value" v-for="choice in option.data">{{choice.name}}</option>
-          </select>
-        </div>
-        <!-- RADIO -->
-        <div v-else-if="option.type === 'radio'">
-
-        </div>
-        <!-- CHECK -->
-        <div v-else-if="option.type === 'check'">
-          {{option.title}} <input type="checkbox" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" v-on:change="checkChange" :checked="config.get(option.id) ? 'checked' : ''">
-        </div>
-        <!-- TEXT -->
-        <div v-else>
-          {{option.title}} <input type="text" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="config.get(option.id)" v-on:change="textChange">
-        </div>
+        <OptionsSelector :meta="meta" :option="option" :config="config" :notice="notice" />
       </div>
     </div>
     <div class="module-notice" v-show="notice">{{notice}}</div>
@@ -31,6 +13,7 @@
 
 <script>
 import HioriSDK from '@sdk'
+import OptionsSelector from './OptionsSelect.vue'
 export default {
   props: [ 'meta' ],
   data() {
@@ -39,24 +22,8 @@ export default {
       notice: ''
     }
   },
-  methods: {
-    dropdownChange: function(evt){
-      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.value, evt.target.getAttribute('data-notice'))
-    },
-    textChange: function(evt){
-      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.value, evt.target.getAttribute('data-notice'))
-    },
-    checkChange: function(evt){
-      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.checked, evt.target.getAttribute('data-notice'))
-    },
-    updateConfig: function(optId, value, notice){
-      if (notice) this.notice = notice
-      this.config.set(optId, value)
-    }
-  },
-  mounted() {
-    // this.config = new HioriSDK.Options(this.meta.name)
-    this.$forceUpdate()
+  components: {
+    OptionsSelector
   }
 }
 </script>

--- a/src/components/OptionsPage.vue
+++ b/src/components/OptionsPage.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="sc3-options-page">
-    <div v-for="moduleKey in Object.keys(modules)">
+    <div v-for="moduleKey in Object.keys(modules)" :key="moduleKey.id">
       <ModuleOptions :meta="modules[moduleKey]" />
     </div>
 	</div>

--- a/src/components/OptionsSelect.vue
+++ b/src/components/OptionsSelect.vue
@@ -1,0 +1,51 @@
+<template>
+  <!-- DROPDOWN -->
+  <div v-if="option.type === 'dropdown'">
+    {{option.title}}
+    <select :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="dropdownChange">
+      <option :value="choice.value" v-for="choice in option.data">{{choice.name}}</option>
+    </select>
+  </div>
+  <!-- RADIO -->
+  <div v-else-if="option.type === 'radio'">
+
+  </div>
+  <!-- CHECK -->
+  <div v-else-if="option.type === 'check'">
+    {{option.title}} <input type="checkbox" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" v-on:change="checkChange" :checked="value ? 'checked' : ''">
+  </div>
+  <!-- TEXT -->
+  <div v-else>
+    {{option.title}} <input type="text" :data-module="meta.name" :data-optid="option.id" :data-notice="option.notice" :value="value" v-on:change="textChange">
+  </div>
+</template>
+
+<script>
+export default {
+  props: [ 'meta', 'option', 'config', 'notice' ],
+  data() {
+    return {
+      value: this.config.get(this.option.id)
+    }
+  },
+  methods: {
+    dropdownChange: function(evt){
+      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.value, evt.target.getAttribute('data-notice'))
+    },
+    textChange: function(evt){
+      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.value, evt.target.getAttribute('data-notice'))
+    },
+    checkChange: function(evt){
+      this.updateConfig(evt.target.getAttribute('data-optid'), evt.target.checked, evt.target.getAttribute('data-notice'))
+    },
+    updateConfig: function(optId, value, notice){
+      if (notice) this.notice = notice
+      this.config.set(optId, value)
+    }
+  },
+  mounted() {
+    // this.config = new HioriSDK.Options(this.meta.name)
+    this.$forceUpdate()
+  }
+}
+</script>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,7 +10,10 @@
     "webRequestBlocking",
     "*://shinycolors.enza.fun/*"
   ],
-  "options_page": "html/options.html",
+  "options_ui": {
+    "open_in_tab": true,
+    "page": "html/options.html"
+  },
   "background": {
     "scripts": [
       "background.js"


### PR DESCRIPTION
* `options_page` is not working on FF, so I changed it to `options_ui` (For test, but also compatible improves) 
* When trying to access options, it get stuck by re-rendering loop by function uses in `:value`.
  * I just trying to split forms to another module, and set Initial value in `data()`. so It can be access on production builds (It's because Vue detect infinite loop only on development build. Fixes #43)
* Fix `[vue/require-v-for-key]` by adding `:key` (Vue's recommends)