### PR TITLE
(Draft) Implements dialog options

### DIFF
--- a/src/entry/background.js
+++ b/src/entry/background.js
@@ -7,9 +7,19 @@ class BackgroundEntry extends HioriSDK.Entry {
     let globalOptions = new HioriSDK.Options('global')
     // Run imported modules
     this.runModules(modules)
+
+    chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+      if (request.method == "getLocalStorage") {
+        sendResponse({config: localStorage.getItem('config')});
+      } else {
+        sendResponse({});
+      }
+    })
   }
 
 }
+
+
 
 let main = new BackgroundEntry()
 main.start()

--- a/src/entry/content.js
+++ b/src/entry/content.js
@@ -13,6 +13,10 @@ class ContentEntry extends HioriSDK.Entry {
       injects.src = chrome.extension.getURL('injects.js')
       document.body.appendChild(injects)
     })
+
+    chrome.runtime.sendMessage({method: "getLocalStorage"}, (response) => {
+      localStorage.setItem('config', response.config)
+    })
   }
 
 }

--- a/src/modules/dialog/injects.js
+++ b/src/modules/dialog/injects.js
@@ -6,7 +6,8 @@ class Dialog extends HioriSDK.ContentScript {
 
   constructor() {
     super()
-    this.lang = 'en_us'
+    if (!this.options.get('enabled')) return;
+    this.lang = this.options.get('lang', 'global')
     this.lastScene = null
     this.lastCommID = null
     this.translations = null
@@ -15,6 +16,7 @@ class Dialog extends HioriSDK.ContentScript {
   }
 
   run() {
+    if (!this.options.get('enabled')) return;
     this.loadTranslations()
     this.modifySceneManager()
   }
@@ -127,7 +129,7 @@ class Dialog extends HioriSDK.ContentScript {
       // Ctrl + Shift + D
       if ( e.ctrlKey == true && e.shiftKey == true && e.which == 68 )
       {
-        // Remove all handlers, so the event doesn't fire twice and 
+        // Remove all handlers, so the event doesn't fire twice and
         // previous non-saved commus don't replicate the event either
         let hdlr = null
         while ( hdlr = self.events.shift() )
@@ -166,7 +168,7 @@ class Dialog extends HioriSDK.ContentScript {
           dialog.text = this.translations[dialog.text]
         }
       }
-      
+
       // Translate choice
       if (dialog.select)
       {


### PR DESCRIPTION
`Options` in injects.js are using webpage's `localStorage`, so I just call extension's `localStorage` by `sendMessage` in `content.js` and store it in the webpage's `localStorage`

Short: It just trying to sync between extension and webpages when page loads.